### PR TITLE
Adding skeleton for encodings. D/E stages

### DIFF
--- a/include/alu.hpp
+++ b/include/alu.hpp
@@ -1,0 +1,27 @@
+#ifndef _ALU_HPP_
+#define _ALU_HPP_
+
+#include "instr.hpp"
+
+constexpr uint8_t ADD_SUB = 0x0;
+constexpr uint8_t SLL = 0x1;
+constexpr uint8_t SLT = 0x2;
+constexpr uint8_t SLTU = 0x3;
+constexpr uint8_t XOR = 0x4;
+constexpr uint8_t SRL_A = 0x5;
+constexpr uint8_t OR = 0x6;
+constexpr uint8_t AND = 0x7;
+
+class ALU : public InstrBase {
+	private:
+		uint8_t funct7;
+		uint8_t rs2;
+		uint8_t rs1;
+		uint8_t funct3;
+		uint8_t rd;
+	public:
+		void decode(uint32_t instr) override;
+		void execute() override;
+};
+
+#endif // _ALU_HAPP_

--- a/include/instr.hpp
+++ b/include/instr.hpp
@@ -1,0 +1,12 @@
+#ifndef _INSTR_HPP_
+#define _INSTR_HPP_
+#include <cstdint>
+
+class InstrBase {
+	public:
+		virtual void decode(uint32_t instr) = 0; // Make decode a pure virtual function
+		virtual void execute() = 0; // Make execute a pure virtual function
+		virtual ~InstrBase() = default; // Virtual destructor
+};
+
+#endif // _INSTR_HPP_

--- a/include/processor.hpp
+++ b/include/processor.hpp
@@ -5,42 +5,17 @@
 //Masks for bit field
 constexpr uint32_t OPCODEMASK = 0x0000007F;
 //Instruction types
-constexpr uint8_t RTYPE = 0x33;
-constexpr uint8_t ITYPE = 0x13;
-constexpr uint8_t STYPE = 0x23;
-constexpr uint8_t BTYPE = 0x63;
-constexpr uint8_t UTYPE = 0x6F;
-constexpr uint8_t JTYPE = 0x67;
+constexpr uint8_t ALUOP    = 0x33;
+constexpr uint8_t ALUIOP   = 0x13;
+constexpr uint8_t STOREOP  = 0x23;
+constexpr uint8_t LOADOP   = 0x03;
+constexpr uint8_t BRANCHOP = 0x63;
+constexpr uint8_t UPPEROP  = 0x6F;
+constexpr uint8_t JUMPOP   = 0x67;
 //Funct3 codes
 //Funct7 codes
 
-
-//structs
-struct iType { 
-	uint16_t imm;
-	uint8_t rs1;
-	uint8_t funct3;
-	uint8_t rd;
-	uint8_t opcode;
-};
-
-struct sType { 
-	uint16_t imm;
-	uint8_t rs2;
-	uint8_t rs1;
-	uint8_t funct3;
-	uint8_t opcode;
-};
-
-union instruction {
-	iType itype;
-	sType stype;
-};
-
 void fetch(void);
-
-void decode(uint32_t instr);
-
-void execute(void);
+void constructMap(void);
 
 #endif //_PROCESSOR_HPP_

--- a/src/alu.cpp
+++ b/src/alu.cpp
@@ -1,0 +1,54 @@
+#include "alu.hpp"
+#include <iostream>
+
+constexpr uint32_t REGMASK = 0x1F;
+constexpr uint32_t F3MASK  = 0x3;
+
+void ALU::decode(uint32_t instr) {
+	funct7  = (instr >> 25);
+	rs2     = (instr >> 20) & REGMASK;
+	rs1     = (instr >> 15) & REGMASK;
+	funct3  = (instr >> 12) & F3MASK;
+	rd      = (instr >> 7)  & REGMASK;
+}
+
+void ALU::execute() {
+	switch (funct3) {
+		case ADD_SUB:
+			if (funct7 == 0) {
+				// do ADD
+			} else {
+				// do SUB
+			}
+			break;
+		case SLL:
+			// do SLL
+			break;
+		case SLT:
+			// do SLT
+			break;
+		case SLTU:
+			// do SLTU
+			break;
+		case XOR:
+			// do XOR
+			break;
+		case SRL_A:
+			if (funct7 == 0) {
+				// do SRL
+			} else {
+				// do SRA
+			}
+			break;
+		case OR:
+			// do OR
+			break;
+		case AND:
+			// do AND
+			break;
+		default:
+			std::cout << "Error in ALU operation" << std::endl;
+			break;
+	}
+}
+

--- a/src/alu.cpp
+++ b/src/alu.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 constexpr uint32_t REGMASK = 0x1F;
-constexpr uint32_t F3MASK  = 0x3;
+constexpr uint32_t F3MASK  = 0x07;
 
 void ALU::decode(uint32_t instr) {
 	funct7  = (instr >> 25);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,9 @@ int main(int argc, char *argv[]) {
     printf("Verbose mode = %b\tFileName = %s\tProg = 0x%x\tStack = 0x%x\n", verboseMode, fileName.c_str(), PROGRAMSTART, STACKADDRESS);
 #endif
 
+    // Construct our encoding map
+    constructMap();
+
     while(1){
     fetch();
     }

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -5,60 +5,42 @@
 #include <memory>
 #include <cstdlib>
 #include <cstdint>
+#include <unordered_map>
+#include "instr.hpp"
+#include "alu.hpp"
 
 extern std::unique_ptr<RegFile> regs;
 extern std::unique_ptr<Memory> mem;
 
-void fetch(void){
+static std::unordered_map<uint8_t, std::unique_ptr<InstrBase>> instrMap;
+
+static std::unique_ptr<ALU> aluOp;
+
+constexpr uint32_t opMask = 0x7F;
+
+void constructMap(void) {
+	// create ALU operation
+	aluOp = std::make_unique<ALU>();
+	instrMap[ALUOP] = std::move(aluOp);
+}
+
+void fetch(void) {
 	uint32_t pc = regs->readPC();
 	uint32_t instr = mem->readWord(pc);
 	regs->updatePC((regs->readPC() + 4));
-	decode(instr);
-	return;
-};
-
-void decode(uint32_t instr){
-	if (instr == 0){
+	
+	// TODO: REMOVE WITH JUMP CLASS DOING THIS
+	if (instr == 0) {
 		regs->print();
-		mem->print();
-		exit(1);
+		mem->print('z');
+		exit(0);
 	}
-	uint8_t opcode = instr & OPCODEMASK;
-	switch (opcode){
-	case (RTYPE):
-		break;
-	case (ITYPE):
-		break;
-	case (STYPE):
-		break;
-	case (BTYPE):
-		break;
-	case (UTYPE):
-		break;
-	case (JTYPE):
-		break;
-	default:
-		break;
-	}
-};
 
-void execute(void){
-	/*	
-		switch (funct3){
-			case(LB):
-				break;
-			case(LH):
-				break;
-			case(LW):
-				break;
-			case(LBU):
-				break;
-			case(LHU):
-				break;
-			default:
-				break;
-		}
-		*/
-};
+	uint8_t opcode = instr & opMask;
+	std::unique_ptr<InstrBase>& opRef = instrMap.at(opcode);
 
+	opRef->decode(instr);
 
+	opRef->execute();
+	return;
+}

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -16,8 +16,6 @@ static std::unordered_map<uint8_t, std::unique_ptr<InstrBase>> instrMap;
 
 static std::unique_ptr<ALU> aluOp;
 
-constexpr uint32_t opMask = 0x7F;
-
 void constructMap(void) {
 	// create ALU operation
 	aluOp = std::make_unique<ALU>();
@@ -36,7 +34,7 @@ void fetch(void) {
 		exit(0);
 	}
 
-	uint8_t opcode = instr & opMask;
+	uint8_t opcode = instr & OPCODEMASK;
 	std::unique_ptr<InstrBase>& opRef = instrMap.at(opcode);
 
 	opRef->decode(instr);


### PR DESCRIPTION
**Motivation**
To add skeleton for how we will add encodings for our Fetch/Decode/Execute instructions

**What changed?**

Updated processor to use unique pointers and unordered map.

Added new map constructor function for main and processor.

Added base instruction type.

Added ALU Register-to-Register type.

Updated constexpr for opcode since we need to different immediate field opcodes.